### PR TITLE
Send fitness fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ Reproducibility is key in simulation studies, so here's how to build the
 project!
 
  1. This module makes use of [Google protocol buffers] for the network serialization
-    install the protobuf code generator for C++ on your system. 
+    install the `protoc` code generator for C++ on your system. [instructions](https://grpc.io/docs/protoc-installation/)
+  
+ 2. Make sure that you have a C++ compiler that has support for at least c++11, and all of the dependencies to install ns-3 installed on your system (see https://www.nsnam.org/wiki/Installation for ns-3 installation instructions)
 
- 2. Download and build copy of the ns-3.32 all-in-one distribution.
+ 3. Download and build copy of the ns-3.32 all-in-one distribution.
 
     ```sh
     wget https://www.nsnam.org/release/ns-allinone-3.32.tar.bz2
@@ -56,20 +58,20 @@ project!
     python3 ./build.py --enable-examples --enable-tests
     ```
 
- 3. Change directories to the `contrib/` folder of the ns-3.32 source
+ 4. Change directories to the `contrib/` folder of the ns-3.32 source
     distribution.
 
     ```sh
     cd ns-3.32/contrib/
     ```
 
- 4. Clone this repository.
+ 5. Clone this repository.
 
     ```sh
     git clone git@github.com:marshallasch/rhpman.git
     ```
 
- 5. Change directory back to the `ns-3.32` folder of the source distribution
+ 6. Change directory back to the `ns-3.32` folder of the source distribution
    and re configure the module through the `waf` tool. 
 
    ```sh
@@ -77,7 +79,7 @@ project!
    ./waf configure --enable-tests --enable-examples
    ```
 
- 6. Change directory back to the `ns-3.32` folder of the source distribution
+ 7. Change directory back to the `ns-3.32` folder of the source distribution
    and run this simulation through the `waf` tool. This will compile the
    simulation code and start executing the code.
 

--- a/examples/rhpman-example.cc
+++ b/examples/rhpman-example.cc
@@ -201,13 +201,11 @@ int main(int argc, char* argv[]) {
 
   LiIonEnergySourceHelper liIonSourceHelper;
   // configure energy source
-  // liIonSourceHelper.Set("BasicEnergySourceInitialEnergyJ", DoubleValue(params.initalPower));
   // install source
   EnergySourceContainer sources = liIonSourceHelper.Install(allAdHocNodes);
   /* device energy model */
   WifiRadioEnergyModelHelper radioEnergyHelper;
   // configure radio energy model
-  // radioEnergyHelper.Set ("TxCurrentA", DoubleValue (0.0174));
   // install device model
   DeviceEnergyModelContainer deviceModels = radioEnergyHelper.Install(adhocDevices, sources);
   /***************************************************************************/

--- a/examples/simulation-params.cc
+++ b/examples/simulation-params.cc
@@ -97,7 +97,6 @@ std::pair<SimulationParameters, bool> SimulationParameters::parse(int argc, char
 
   bool optStaggeredStart = false;
 
-  double optInitalPower = 20000;
   double optLowPowerThreshold = 0.0;
 
   // Animation parameters.
@@ -115,10 +114,6 @@ std::pair<SimulationParameters, bool> SimulationParameters::parse(int argc, char
       "percentDataOwners",
       "Percent of nodes who have original data to deciminate",
       optPercentageDataOwners);
-  //  cmd.AddValue(
-  //      "initalPower",
-  //      "Amount of inital battery power that each node starts with (J)",
-  //      optInitalPower);
   cmd.AddValue(
       "lowPowerThreshold",
       "The battery precentage at which a node will step down as a replication node if it drops "
@@ -370,7 +365,6 @@ std::pair<SimulationParameters, bool> SimulationParameters::parse(int argc, char
   result.storageSpace = optStorageSpace;
   result.bufferSpace = optBufferSpace;
 
-  result.initalPower = optInitalPower;
   result.lowPowerThreshold = optLowPowerThreshold;
 
   result.staggeredStart = optStaggeredStart;

--- a/examples/simulation-params.h
+++ b/examples/simulation-params.h
@@ -94,7 +94,6 @@ class SimulationParameters {
 
   bool staggeredStart;
 
-  double initalPower;
   double lowPowerThreshold;
 
   uint32_t storageSpace;

--- a/model/proto/messages.proto
+++ b/model/proto/messages.proto
@@ -11,18 +11,13 @@ message Message {
         Request request = 4;
         Response response = 5;
         ElectionRequest election = 6;
-        ElectionFitness fitness = 7;
-        ModeChange mode_change = 8;
-        Store store = 9;
-        Transfer transfer = 10;
+        ModeChange mode_change = 7;
+        Store store = 8;
+        Transfer transfer = 9;
     }
 }
 
 message ElectionRequest {
-}
-
-message ElectionFitness {
-    double fitness = 1;
 }
 
 message ModeChange {
@@ -32,7 +27,8 @@ message ModeChange {
 
 message Ping {
     double delivery_probability = 1;
-    bool replicating_node = 2;
+    double fitness = 2;
+    bool replicating_node = 3;
 }
 
 message Request {

--- a/model/rhpman-stats.cc
+++ b/model/rhpman-stats.cc
@@ -44,8 +44,6 @@ std::string Stats::TypeString(Stats::Type type) {
       return "MODE_CHANGE";
     case ELECTION_REQUEST:
       return "ELECTION_REQUEST";
-    case ELECTION_FITNESS:
-      return "ELECTION_FITNESS";
     case STORE:
       return "STORE";
     case LOOKUP:

--- a/model/rhpman-stats.cc
+++ b/model/rhpman-stats.cc
@@ -38,21 +38,21 @@ Stats::~Stats() {}
 
 std::string Stats::TypeString(Stats::Type type) {
   switch (type) {
-    case PING:
+    case Type::PING:
       return "PING";
-    case MODE_CHANGE:
+    case Type::MODE_CHANGE:
       return "MODE_CHANGE";
-    case ELECTION_REQUEST:
+    case Type::ELECTION_REQUEST:
       return "ELECTION_REQUEST";
-    case STORE:
+    case Type::STORE:
       return "STORE";
-    case LOOKUP:
+    case Type::LOOKUP:
       return "LOOKUP";
-    case LOOKUP_RESPONSE:
+    case Type::LOOKUP_RESPONSE:
       return "LOOKUP_RESPONSE";
-    case TRANSFER:
+    case Type::TRANSFER:
       return "TRANSFER";
-    case UNKOWN:
+    case Type::UNKOWN:
     default:
       return "UNKOWN";
   }
@@ -132,12 +132,12 @@ void Stats::addPending(uint64_t num) { pending += num; }
 // stats related to messages
 void Stats::incSent(Stats::Type type, uint32_t expectedRecipients) {
   totalSent += expectedRecipients;
-  sentCounters[type] += expectedRecipients;
+  sentCounters[static_cast<int>(type)] += expectedRecipients;
 }
 
 void Stats::incReceived(Stats::Type type) {
   totalReceived++;
-  receivedCounters[type]++;
+  receivedCounters[static_cast<int>(type)]++;
 }
 
 void Stats::incDuplicate() { duplicatesReceived++; }

--- a/model/rhpman-stats.h
+++ b/model/rhpman-stats.h
@@ -3,7 +3,7 @@
 #ifndef __RHPMAN_STATS_H_
 #define __RHPMAN_STATS_H_
 
-#define TYPE_ENUM_SIZE 9
+#define TYPE_ENUM_SIZE 8
 
 #include "ns3/uinteger.h"
 
@@ -17,7 +17,6 @@ class Stats {
     PING,
     MODE_CHANGE,
     ELECTION_REQUEST,
-    ELECTION_FITNESS,
     STORE,
     LOOKUP,
     LOOKUP_RESPONSE,

--- a/model/rhpman-stats.h
+++ b/model/rhpman-stats.h
@@ -12,7 +12,7 @@ using namespace ns3;
 
 class Stats {
  public:
-  enum Type {
+  enum class Type {
     UNKOWN = 0,
     PING,
     MODE_CHANGE,

--- a/model/rhpman.cc
+++ b/model/rhpman.cc
@@ -907,8 +907,8 @@ void RhpmanApp::MakeNonReplicaHolderNode() {
   SendRoleChange(0);
   stats.incStepDown();
 
-  // does not transfer storage if it is an election stepdown, nothing was described for this
-  // only hand off it stepping down
+  uint32_t newReplicaNode = GetNextBestReplicaNode();
+  TransferStorage(newReplicaNode, true);
 }
 
 // this will send the synchonous data lookup requests to all of the known replica holder nodes
@@ -1041,9 +1041,7 @@ void RhpmanApp::ExitCheck() {
   if (m_role != Role::REPLICATING) return;
 
   if (GetEnergyLevel() < m_low_power_threshold) {
-    uint32_t newReplicaNode = GetNextBestReplicaNode();
     MakeNonReplicaHolderNode();
-    TransferStorage(newReplicaNode, true);
   }
 }
 

--- a/model/rhpman.h
+++ b/model/rhpman.h
@@ -108,6 +108,8 @@ class RhpmanApp : public Application {
   static void CleanUp();
 
  private:
+  enum StorageType { BUFFER = 0, STORAGE };
+
   // Application lifecycle methods.
 
   void StartApplication() override;
@@ -199,7 +201,9 @@ class RhpmanApp : public Application {
       const std::set<uint32_t> addresses,
       const std::set<uint32_t> exclude);
   std::set<uint32_t> FilterAddress(const std::set<uint32_t> addresses, uint32_t exclude);
-  void TransferBuffer(uint32_t nodeID, bool stepUp);
+  void TransferBuffer(uint32_t nodeID);
+  void TransferStorage(uint32_t nodeID, bool stepUp);
+  void SendStorage(uint32_t nodeID, StorageType type, bool stepUp);
   DataItem* CheckLocalStorage(uint64_t dataID);
 
   Ptr<Socket> SetupSocket(uint16_t port, uint32_t ttl);
@@ -220,6 +224,7 @@ class RhpmanApp : public Application {
   void RefreshRoutingTable();
   std::string GetRoutingTableString();
   uint32_t CountExpectedRecipients(uint32_t hops);
+  uint32_t GetNextBestReplicaNode();
 
   void PowerLossHandler();
   void PowerRechargedHandler();

--- a/model/rhpman.h
+++ b/model/rhpman.h
@@ -65,7 +65,7 @@ using namespace ns3;
 ///     App instances which are not data owners will have negative a DataId.
 class RhpmanApp : public Application {
  public:
-  enum Role { NON_REPLICATING = 0, REPLICATING };
+  enum class Role { NON_REPLICATING = 0, REPLICATING };
 
   /// \brief Identifies the lifecycle state of this app.
   enum class State { NOT_STARTED = 0, RUNNING, STOPPED };

--- a/simulation.py
+++ b/simulation.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+
+
+#
+# This was run using commit cf4e71d
+#
+#
+#   Note this script is not designed to be run from this directory this is here so that it can be shared with the rest
+#   of the lab group as an example. This should be run from outside of the ns3 folder, currently in an example folder
+# 
+#  /
+#      ns-3-allinone/
+#          .....
+#      experiment/
+#          simulation.py
+# 
+#   This script should be run from the experiment directory
+#
+
+import sem
+import seaborn as sns
+import matplotlib.pyplot as plt
+import os
+
+ns_path = '../ns-3-allinone/ns-3.32'
+script = 'rhpman-example'
+campaign_dir = './rhpman_fitness'
+figure_dir = './fig'
+
+campaign = sem.CampaignManager.new(ns_path, script, campaign_dir, max_parallel_processes=10)
+
+
+def getNumNodes(param):
+    return param['totalNodes']
+
+def getCarryingThreshold(param):
+    if param['hops'] == 2 and param['totalNodes'] == 160:
+        return [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+    else:
+        return [0.4]
+
+
+def getForwardingThreshold(param):
+    if param['hops'] == 2 and param['totalNodes'] == 160 and param['carryingThreshold'] == 0.4:
+        return [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+    else:
+        return [0.6]
+
+
+param_combination = {
+    'runTime': [2400],
+    'waitTime': [600],
+    'lookupTime': [30],
+    'updateTime': [120],
+    'dataSize': [512],
+    'profileUpdateDelay': [6],
+
+    'totalNodes': [160, 200], #[40, 80, 120, 160, 200],
+    'storageSpace': lambda p: p['totalNodes'], # [40], #getNumNodes,
+    'bufferSpace': lambda p: p['totalNodes'], # [40], #getNumNodes,
+
+    'wcdc': [0.5],
+    'wcol': [0.5],
+
+    'hops': lambda p: [2] if p['totalNodes'] != 160 else [1, 2, 3, 4, 5], # [2]
+    'replicationHops': [4],
+
+    'carryingThreshold': getCarryingThreshold, # lambda p: [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], # [0.4], #
+    'forwardingThreshold': getForwardingThreshold,  #[0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], # [0.6], #
+
+    'percentDataOwners': [10],
+    'areaWidth': [1000],
+    'areaLength': [1000],
+
+    'gridRows': [4],
+    'gridCols': [4],
+    'wifiRadius': [100],
+    'partitionNodes': [8],
+
+    'travellerVelocity': [20],
+    'travellerWalkMode': ['time'],
+    'travellerWalkTime': [100],
+    'pbnVelocityMin': [1],
+    'pbnVelocityMax': [10],
+    'pbnVelocityChangeAfter': [100],
+    'routing': ['dsdv'],
+    'travellerWalkDist': [0],
+    'requestTimeout': [0],
+    'peerTimeout': [6],
+    'electionPeriod': [6],
+    'electionCooldown': lambda p: p['electionPeriod'],
+
+    'storageWeight': [ 0.5 ],
+    'energyWeight': [ 0.5 ],
+    'processingWeight': [0],
+    'staggeredStart': [True, False],
+    'lowPowerThreshold': [0.4]
+
+}
+
+carrying_params = {
+    'runTime': [2400],
+    'waitTime': [600],
+    'lookupTime': [30],
+    'updateTime': [120],
+    'dataSize': [512],
+    'profileUpdateDelay': [6],
+
+    'totalNodes': [160],
+    'storageSpace': lambda p: p['totalNodes'], # [40], #getNumNodes,
+    'bufferSpace': lambda p: p['totalNodes'], # [40], #getNumNodes,
+
+    'wcdc': [0.5],
+    'wcol': [0.5],
+
+    'hops': [2],
+    'replicationHops': [4],
+
+    'carryingThreshold': [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0], # [0.4], #
+    'forwardingThreshold': [0.6],
+
+    'percentDataOwners': [10],
+    'areaWidth': [1000],
+    'areaLength': [1000],
+
+    'gridRows': [4],
+    'gridCols': [4],
+    'wifiRadius': [100],
+    'partitionNodes': [8],
+
+    'travellerVelocity': [20],
+    'travellerWalkMode': ['time'],
+    'travellerWalkTime': [100],
+    'pbnVelocityMin': [1],
+    'pbnVelocityMax': [10],
+    'pbnVelocityChangeAfter': [100],
+    'routing': ['dsdv'],
+    'travellerWalkDist': [0],
+    'requestTimeout': [0],
+    'peerTimeout': [6],
+    'electionPeriod': [6],
+    'electionCooldown': lambda p: p['electionPeriod'],
+
+    'storageWeight': [ 0.5 ],
+    'energyWeight': [ 0.5 ],
+    'processingWeight': [0],
+    'staggeredStart': [True, False],
+    'lowPowerThreshold': [0.4]
+}
+
+forwarding_params = {
+    'runTime': [2400],
+    'waitTime': [600],
+    'lookupTime': [30],
+    'updateTime': [120],
+    'dataSize': [512],
+    'profileUpdateDelay': [6],
+
+    'totalNodes': [160],
+    'storageSpace': lambda p: p['totalNodes'], # [40], #getNumNodes,
+    'bufferSpace': lambda p: p['totalNodes'], # [40], #getNumNodes,
+
+    'wcdc': [0.5],
+    'wcol': [0.5],
+
+    'hops': [2],
+    'replicationHops': [4],
+
+    'carryingThreshold': [0.4], #
+    'forwardingThreshold': [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+
+    'percentDataOwners': [10],
+    'areaWidth': [1000],
+    'areaLength': [1000],
+
+    'gridRows': [4],
+    'gridCols': [4],
+    'wifiRadius': [100],
+    'partitionNodes': [8],
+
+    'travellerVelocity': [20],
+    'travellerWalkMode': ['time'],
+    'travellerWalkTime': [100],
+    'pbnVelocityMin': [1],
+    'pbnVelocityMax': [10],
+    'pbnVelocityChangeAfter': [100],
+    'routing': ['dsdv'],
+    'travellerWalkDist': [0],
+    'requestTimeout': [0],
+    'peerTimeout': [6],
+    'electionPeriod': [6],
+    'electionCooldown': lambda p: p['electionPeriod'],
+
+    'storageWeight': [ 0.5 ],
+    'energyWeight': [ 0.5 ],
+    'processingWeight': [0],
+    'staggeredStart': [True, False],
+    'lowPowerThreshold': [0.4],
+}
+
+totalnodes_params = {
+    'runTime': [2400],
+    'waitTime': [600],
+    'lookupTime': [30],
+    'updateTime': [120],
+    'dataSize': [512],
+    'profileUpdateDelay': [6],
+
+    'totalNodes': [160, 200], #[40, 80, 120, 160, 200],
+    'storageSpace': lambda p: p['totalNodes'], # [40], #getNumNodes,
+    'bufferSpace': lambda p: p['totalNodes'], # [40], #getNumNodes,
+
+    'wcdc': [0.5],
+    'wcol': [0.5],
+
+    'hops': [2],
+    'replicationHops': [4],
+
+    'percentDataOwners': [10],
+    'areaWidth': [1000],
+    'areaLength': [1000],
+
+    'gridRows': [4],
+    'gridCols': [4],
+    'wifiRadius': [100],
+    'partitionNodes': [8],
+
+    'travellerVelocity': [20],
+    'travellerWalkMode': ['time'],
+    'travellerWalkTime': [100],
+    'pbnVelocityMin': [1],
+    'pbnVelocityMax': [10],
+    'pbnVelocityChangeAfter': [100],
+    'routing': ['dsdv'],
+    'travellerWalkDist': [0],
+    'requestTimeout': [0],
+    'peerTimeout': [6],
+    'electionPeriod': [6],
+    'electionCooldown': lambda p: p['electionPeriod'],
+
+    'storageWeight': [ 0.5 ],
+    'energyWeight': [ 0.5 ],
+    'processingWeight': [0],
+    'staggeredStart': [True, False],
+    'lowPowerThreshold': [0.4],
+}
+
+hops_params = {
+    'runTime': [2400],
+    'waitTime': [600],
+    'lookupTime': [30],
+    'updateTime': [120],
+    'dataSize': [512],
+    'profileUpdateDelay': [6],
+
+    'totalNodes': [160],
+    'storageSpace': lambda p: p['totalNodes'],
+    'bufferSpace': lambda p: p['totalNodes'],
+
+    'wcdc': [0.5],
+    'wcol': [0.5],
+
+    'hops':  [1, 2, 3, 4, 5], # [2]
+    'replicationHops': [4],
+
+    'carryingThreshold': [0.4],
+    'forwardingThreshold': [0.6],
+
+    'percentDataOwners': [10],
+    'areaWidth': [1000],
+    'areaLength': [1000],
+
+    'gridRows': [4],
+    'gridCols': [4],
+    'wifiRadius': [100],
+    'partitionNodes': [8],
+
+    'travellerVelocity': [20],
+    'travellerWalkMode': ['time'],
+    'travellerWalkTime': [100],
+    'pbnVelocityMin': [1],
+    'pbnVelocityMax': [10],
+    'pbnVelocityChangeAfter': [100],
+    'routing': ['dsdv'],
+    'travellerWalkDist': [0],
+    'requestTimeout': [0],
+    'peerTimeout': [6],
+    'electionPeriod': [6],
+    'electionCooldown': lambda p: p['electionPeriod'],
+
+    'storageWeight': [ 0.5 ],
+    'energyWeight': [ 0.5 ],
+    'processingWeight': [0],
+    'staggeredStart': [True, False],
+    'lowPowerThreshold': [0.4]
+}
+
+
+
+campaign.run_missing_simulations(param_combination, runs=30, stop_on_errors=False)
+
+
+
+#print(campaign.get_space(param_space=param_combination, runs=30))
+
+#exit(0)
+
+#def getMessages(r):
+#    return float(r['output']['stdout'].split('\n')[2].split('\t')[1])
+
+
+
+@sem.utils.output_labels([
+    'successRatio',
+    'InitalTotalSaves', 'InitalTotalLookups', 'InitalTotalSuccess', 'InitalTotalFailed', 'InitalTotalLate', 'InitalTotalCacheHits', 'InitalTotalPending', 'InitalTotalStepUp', 'InitalTotalStepDowns', 'InitalTotalPowerloss', 'InitalTotalPowerRecharge', 'InitalTotalSent', 'InitalTotalReceived', 'InitalTotalDuplicates', 'InitalTotalSentUNKOWN', 'InitalTotalSentPING', 'InitalTotalSentMODE_CHANGE', 'InitalTotalSentELECTION_REQUEST', 'InitalTotalSentSTORE', 'InitalTotalSentLOOKUP', 'InitalTotalSentLOOKUP_RESPONSE', 'InitalTotalSentTRANSFER', 'InitalTotalReceivedUNKOWN', 'InitalTotalReceivedPING', 'InitalTotalReceivedMODE_CHANGE', 'InitalTotalReceivedELECTION_REQUEST', 'InitalTotalReceivedSTORE', 'InitalTotalReceivedLOOKUP', 'InitalTotalReceivedLOOKUP_RESPONSE', 'InitalTotalReceivedTRANSFER',
+    'FinalTotalSaves', 'FinalTotalLookups', 'FinalTotalSuccess', 'FinalTotalFailed', 'FinalTotalLate', 'FinalTotalCacheHits', 'FinalTotalPending', 'FinalTotalStepUp', 'FinalTotalStepDowns', 'FinalTotalPowerloss', 'FinalTotalPowerRecharge', 'FinalTotalSent', 'FinalTotalReceived', 'FinalTotalDuplicates', 'FinalTotalSentUNKOWN', 'FinalTotalSentPING', 'FinalTotalSentMODE_CHANGE', 'FinalTotalSentELECTION_REQUEST', 'FinalTotalSentSTORE', 'FinalTotalSentLOOKUP', 'FinalTotalSentLOOKUP_RESPONSE', 'FinalTotalSentTRANSFER', 'FinalTotalReceivedUNKOWN', 'FinalTotalReceivedPING', 'FinalTotalReceivedMODE_CHANGE', 'FinalTotalReceivedELECTION_REQUEST', 'FinalTotalReceivedSTORE', 'FinalTotalReceivedLOOKUP', 'FinalTotalReceivedLOOKUP_RESPONSE', 'FinalTotalReceivedTRANSFER'
+    ])
+@sem.utils.only_load_some_files(['stdout'])
+def get_all(result):
+    if result['output']['stdout'] == "":
+        return [float(-1)]
+    lines = result['output']['stdout'].strip().split('\n')
+    res = { r.split('\t')[0]: float(r.split('\t')[1]) for r in lines}
+    successRatio = res['FinalTotalSuccess'] / (res['FinalTotalFailed'] + res['FinalTotalPending'])
+    return [successRatio] + [float(r.split('\t')[1]) for r in lines]
+
+
+hopData = campaign.get_results_as_dataframe(get_all, params=hops_params)
+sns.catplot(data=hopData,
+            x='hops',
+            y='FinalTotalSent',
+            col='staggeredStart',
+            kind='point'
+            )
+plt.savefig(os.path.join(figure_dir, 'hops_traffic_energy_fix_a.pdf'))
+
+sns.catplot(data=hopData,
+            x='hops',
+            y='successRatio',
+            col='staggeredStart',
+            kind='point'
+            )
+plt.savefig(os.path.join(figure_dir, 'hops_success_ratio_energy_fix_a.pdf'))
+
+
+nodesData = campaign.get_results_as_dataframe(get_all, params=totalnodes_params)
+sns.catplot(data=nodesData,
+            x='totalNodes',
+            y='FinalTotalSent',
+            col='staggeredStart',
+            kind='point'
+            )
+plt.savefig(os.path.join(figure_dir, 'nodes_traffic_energy_fix_a.pdf'))
+
+sns.catplot(data=nodesData,
+            x='totalNodes',
+            y='successRatio',
+            col='staggeredStart',
+            kind='point'
+            )
+plt.savefig(os.path.join(figure_dir, 'nodes_success_ratio_energy_fix_a.pdf'))
+
+
+
+carryingData = campaign.get_results_as_dataframe(get_all, params=carrying_params)
+sns.catplot(data=carryingData,
+            x='carryingThreshold',
+            y='FinalTotalSent',
+            col='staggeredStart',
+            kind='point'
+            )
+plt.savefig(os.path.join(figure_dir, 'carrying_traffic_energy_fix_a.pdf'))
+
+sns.catplot(data=carryingData,
+            x='carryingThreshold',
+            y='successRatio',
+            col='staggeredStart',
+            kind='point'
+            )
+plt.savefig(os.path.join(figure_dir, 'carrying_success_ratio_energy_fix_a.pdf'))
+
+
+forwardingData = campaign.get_results_as_dataframe(get_all, params=forwarding_params)
+sns.catplot(data=forwardingData,
+            x='forwardingThreshold',
+            y='FinalTotalSent',
+            col='staggeredStart',
+            kind='point'
+            )
+plt.savefig(os.path.join(figure_dir, 'forwarding_traffic_energy_fix_a.pdf'))
+
+sns.catplot(data=forwardingData,
+            x='forwardingThreshold',
+            y='successRatio',
+            col='staggeredStart',
+            kind='point'
+            )
+plt.savefig(os.path.join(figure_dir, 'forwarding_success_ratio_energy_fix_a.pdf'))


### PR DESCRIPTION
This should now include the fitness value in the ping message that gets sent, this should result in less overall network traffic, (although the old send fitness was never actually implemented so it should have minimal impact). 

When a node is stepping down due to a low power event the contents of the devices storage will be transferred to the next best node, that node will also step up to become a replica holder node. 

Note that as of the current implementation if a node steps down as the result of an election it will **NOT** transfer the contents of its storage to the new replica holder node. Although this should probably be implemented before this is merged.

- if a node steps down because it detects that a different node is to be elected it should check who that node is and send them all the data , note it should not matter if the message is sent with the appoint as replica holder flag because that node should also determine that it is stepping up as a replica holder. However there is the edge case where the network is configured as

```
A  ---- B ----  C ---- D 
```

and A > B > C > D, if h_r = 1 then 
and D used to be a replica holder

- D will not think it is elected because C is higher
- C will not think it is elected because B is higher
- B will not think it is elected because C is higher
- A will be elected, but there is no node within one hop of D, so it is okay that it hands off to C and makes C a replica holdr as that will cause that there to be least one replica holder within h_r hops of any node.
